### PR TITLE
Add dev dependencies

### DIFF
--- a/debian8_dev/Dockerfile
+++ b/debian8_dev/Dockerfile
@@ -33,6 +33,13 @@ RUN apt-get update && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Install Python 3.6 needed by black for our pre-commits
+RUN curl 'https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz' | tar -xz -C /tmp/      \
+    && cd /tmp/Python-3.6.8     \
+    && ./configure              \
+    && make -j$(nproc)          \
+    && make altinstall
+
 # Add address of the canaltp.local apt server
 RUN echo "nameserver 10.50.83.15" > /etc/resolv.conf \
 		&& apt-get update \
@@ -40,13 +47,14 @@ RUN echo "nameserver 10.50.83.15" > /etc/resolv.conf \
 		# Get the gpg key to authorize downloads from local apt server
 		&& wget --output-document=- http://apt.canaltp.local/debian/repositories/canaltp.gpg.key | apt-key add - \
 		&& apt-get -y --force-yes -t jessie-dev install libosmpbf-dev python-protobuf \
-		&& apt-get clean \
-		&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+		&& apt-get clean
 
-RUN pip install pip virtualenv -U && \
+RUN pip install pip virtualenv pipenv -U && \
 	# install dependancies for libc
-	pip install ujson==1.33 numpy==1.9 && \
-	rm -rf /tmp/* /var/tmp/* ~/.cache/pip/*
+	pip install ujson==1.33 numpy==1.9
+
+# Clean up the environment
+RUN rm -rf /tmp/* /var/tmp/* ~/.cache/pip/* /var/lib/apt/lists/* /tmp/*
 
 # add user and group jenkins, with specific userid and groupid, never fail
 RUN groupadd -g 115 jenkins; exit 0

--- a/debian8_dev/Dockerfile
+++ b/debian8_dev/Dockerfile
@@ -38,7 +38,8 @@ RUN curl 'https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz' | tar -xz -C
     && cd /tmp/Python-3.6.8     \
     && ./configure              \
     && make -j$(nproc)          \
-    && make altinstall
+    && make altinstall		\
+    && rm -rf /tmp/*
 
 # Add address of the canaltp.local apt server
 RUN echo "nameserver 10.50.83.15" > /etc/resolv.conf \
@@ -47,14 +48,13 @@ RUN echo "nameserver 10.50.83.15" > /etc/resolv.conf \
 		# Get the gpg key to authorize downloads from local apt server
 		&& wget --output-document=- http://apt.canaltp.local/debian/repositories/canaltp.gpg.key | apt-key add - \
 		&& apt-get -y --force-yes -t jessie-dev install libosmpbf-dev python-protobuf \
-		&& apt-get clean
+		&& apt-get clean \
+		&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN pip install pip virtualenv pipenv -U && \
 	# install dependancies for libc
-	pip install ujson==1.33 numpy==1.9
-
-# Clean up the environment
-RUN rm -rf /tmp/* /var/tmp/* ~/.cache/pip/* /var/lib/apt/lists/* /tmp/*
+	pip install ujson==1.33 numpy==1.9 && \
+	rm -rf /tmp/* /var/tmp/* ~/.cache/pip/*
 
 # add user and group jenkins, with specific userid and groupid, never fail
 RUN groupadd -g 115 jenkins; exit 0

--- a/debian9_dev/Dockerfile
+++ b/debian9_dev/Dockerfile
@@ -3,6 +3,9 @@ FROM debian:9
 ENV TZ=Europe/Paris
 RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/Europe/Paris /etc/localtime
 
+# Install backport to install clang-format-6.0
+RUN echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/stretch-backport.list
+
 RUN apt-get update && \
 	apt-get install -y \
 		git \
@@ -29,20 +32,27 @@ RUN apt-get update && \
 		vim \
         libosmpbf-dev \
         python-protobuf \
-        libssl-dev && \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+        clang-format-6.0 \
+        libssl-dev
 
+# Install Python 3.6 needed by black for our pre-commits
+RUN curl 'https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz' | tar -xz -C /tmp/      \
+    && cd /tmp/Python-3.6.8     \
+    && ./configure              \
+    && make -j$(nproc)          \
+    && make altinstall
 
 # we can't use pip from system it's too old
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py \
-    && pip install -U virtualenv  && \
+    && pip install -U virtualenv pipenv && \
 	# install dependancies for libc
-	pip install ujson==1.33 numpy==1.9 && \
-	rm -rf /tmp/* /var/tmp/* ~/.cache/pip/*
+	pip install ujson==1.33 numpy==1.9
 
 # add user and group jenkins, with specific userid and groupid, never fail
 RUN groupadd -g 115 jenkins; exit 0
 RUN useradd -u 109 -g 115 jenkins | chpasswd; exit 0
+
+# Clean up
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache/pip/*
 
 CMD ["/usr/sbin/rabbitmq-server"]

--- a/debian9_dev/Dockerfile
+++ b/debian9_dev/Dockerfile
@@ -33,26 +33,27 @@ RUN apt-get update && \
         libosmpbf-dev \
         python-protobuf \
         clang-format-6.0 \
-        libssl-dev
+        libssl-dev && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Python 3.6 needed by black for our pre-commits
 RUN curl 'https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz' | tar -xz -C /tmp/      \
     && cd /tmp/Python-3.6.8     \
     && ./configure              \
     && make -j$(nproc)          \
-    && make altinstall
+    && make altinstall		\
+    && rm -rf /tmp/*
 
 # we can't use pip from system it's too old
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py \
     && pip install -U virtualenv pipenv && \
 	# install dependancies for libc
-	pip install ujson==1.33 numpy==1.9
+	pip install ujson==1.33 numpy==1.9 && \
+	rm -rf /tmp/* /var/tmp/* ~/.cache/pip/*
 
 # add user and group jenkins, with specific userid and groupid, never fail
 RUN groupadd -g 115 jenkins; exit 0
 RUN useradd -u 109 -g 115 jenkins | chpasswd; exit 0
-
-# Clean up
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache/pip/*
 
 CMD ["/usr/sbin/rabbitmq-server"]

--- a/ubuntu18_dev/Dockerfile
+++ b/ubuntu18_dev/Dockerfile
@@ -24,11 +24,12 @@ RUN apt-get update \
 	 	python \
 	 	python-pip \
 	 	rabbitmq-server \
+        clang-format-6.0 \
 	 	curl
 
 RUN curl -q https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
  && python /tmp/get-pip.py \
- && pip install -U virtualenv \
+ && pip install -U virtualenv pipenv \
  	# install dependancies for libc \
  && pip install ujson==1.33 numpy==1.9
 

--- a/ubuntu18_dev/Dockerfile
+++ b/ubuntu18_dev/Dockerfile
@@ -24,19 +24,20 @@ RUN apt-get update \
 	 	python \
 	 	python-pip \
 	 	rabbitmq-server \
-        clang-format-6.0 \
-	 	curl
+	 	clang-format-6.0 \
+	 	curl 	\
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN curl -q https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
- && python /tmp/get-pip.py \
- && pip install -U virtualenv pipenv \
- 	# install dependancies for libc \
- && pip install ujson==1.33 numpy==1.9
+    && python /tmp/get-pip.py               \
+    && pip install -U virtualenv pipenv     \
+ 	# install dependancies for libc         \
+    && pip install ujson==1.33 numpy==1.9	\
+    && rm -rf /tmp/* /var/tmp/* ~/.cache/pip/*
 
 # add user and group jenkins, with specific userid and groupid, never fail
 RUN groupadd -g 115 jenkins; exit 0
 RUN useradd -u 109 -g 115 jenkins | chpasswd; exit 0
-
-RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache/pip/* && apt clean
 
 CMD ["/usr/sbin/rabbitmq-server"]


### PR DESCRIPTION
Since we've added `pre-commit`, we now have dependencies on python-3.6 for running black and clang-format-6.0.

`pipenv` is also added for the new release script (see. [navitia/pull/2769](https://github.com/CanalTP/navitia/pull/2769)) and so that we could gradually migrate away from `virtualenv` when needed. 
