### PR TITLE
Docker image navitia/python FROM debian

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update --fix-missing \
         automake \
         autoconf \
         libtool \ 
-	&&	pip install --upgrade pip && pip install uwsgi \
+    &&  pip install --upgrade pip && pip install uwsgi \
     &&  wget https://github.com/protocolbuffers/protobuf/archive/v3.3.2.tar.gz && tar -xf v3.3.2.tar.gz \
     &&  cd protobuf-3.3.2 \ 
     &&  ./autogen.sh && ./configure && make -j$(grep -c vendor_id /proc/cpuinfo) && make install \ 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,36 +1,35 @@
-FROM alpine:3.8
+FROM debian:8
 
 LABEL "io.navitia.name"="navitia/python"
 
 WORKDIR /
-RUN apk --update --no-cache add \
-    g++ \
-    build-base \
-    libstdc++ \
-    python \
-    musl-dev \
-    linux-headers \
-    python-dev \
-    py2-pip \
-    git \
-    curl \
-    automake \
-    autoconf \
-    libtool && \
-    pip install  --no-cache-dir -U pip && \
-    pip install --no-cache-dir uwsgi && \
-    git clone https://github.com/google/protobuf.git && cd protobuf && \
-    git checkout v3.3.0 && ./autogen.sh && ./configure && make -j$(grep -c vendor_id /proc/cpuinfo) && \
-    make install && \
-    cd python && python setup.py install --cpp_implementation && \
-    cd / && rm -rf protobuf && apk del \
-        g++ \
-        build-base \
+
+RUN apt-get update --fix-missing \
+    &&  apt-get upgrade -y \
+    &&  apt-get install -y \
+        libpython2.7 \
+        python \
         python-dev \
-        git \
+        python-pip \
+        wget \
         curl \
+        unzip \
+        automake \
+        autoconf \
+        libtool \ 
+	&&	pip install --upgrade pip && pip install uwsgi \
+    &&  wget https://github.com/protocolbuffers/protobuf/archive/v3.3.2.tar.gz && tar -xf v3.3.2.tar.gz \
+    &&  cd protobuf-3.3.2 \ 
+    &&  ./autogen.sh && ./configure && make -j$(grep -c vendor_id /proc/cpuinfo) && make install \ 
+    &&  cd python && python setup.py install --cpp_implementation \
+    &&  cd / \
+    &&  rm -f v3.3.2.tar.gz && rm -rf protobuf* \
+    &&  apt-get autoremove -y \
+        python-dev \
+        python-pip \
+        curl \
+        unzip \
         automake \
         autoconf \
         libtool \
-        musl-dev \
-        linux-headers
+        wget


### PR DESCRIPTION
The navitia/python image was based on alpine. One of the lib used for navitia (libgeos) is now incompatible with alpine as well as others found after investigation (ujson).
See https://github.com/CanalTP/navitia-docker-compose/issues/61 and https://github.com/esnme/ultrajson/issues/326

It has been decided that the image will be based on debian from now on.