### PR TITLE
Remove dependencies on apt.canaltp.local repo

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -12,7 +12,7 @@ jobs:
 
       strategy:
           matrix:
-              docker_image_name: [debian9_dev, debian10_dev]
+              docker_image_name: [debian8_dev, debian9_dev, debian10_dev]
 
       steps:
       - uses: actions/checkout@v2

--- a/debian8_dev/Dockerfile
+++ b/debian8_dev/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && \
 		libgoogle-perftools4 \
 		libgoogle-perftools-dev \
 		vim && \
+    apt-get install -y autoconf automake libtool curl make g++ unzip && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -37,20 +38,22 @@ RUN wget 'https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz' -O - | tar -
     && make altinstall		\
     && rm -rf /tmp/*
 
-# Add address of the canaltp.local apt server
-RUN echo "deb http://apt.canaltp.local/debian/repositories jessie-dev main" > /etc/apt/sources.list.d/canaltp.list
-RUN echo "nameserver 10.50.83.15" > /etc/resolv.conf \
-		&& apt-get update \
-		# Get the gpg key to authorize downloads from local apt server
-		&& wget --output-document=- http://apt.canaltp.local/debian/repositories/canaltp.gpg.key | apt-key add - \
-		&& apt-get -y --force-yes -t jessie-dev install libosmpbf-dev libprotobuf-dev protobuf-compiler python-protobuf \
-		&& apt-get clean \
-		&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Build and Install Protobuf
+RUN wget 'https://github.com/protocolbuffers/protobuf/archive/v3.3.1.tar.gz' -O - | tar -xz -C /tmp/ \
+    && cd /tmp/protobuf-3.3.1/  \
+    && ./autogen.sh \ 
+    && ./configure --prefix=/usr \
+    && make \
+    && make install \
+    && ldconfig \
+    && rm -rf /tmp/*
 
-RUN pip install pip virtualenv pipenv -U && \
-	# install dependancies for libc
-	pip install ujson==1.33 numpy==1.9 && \
-	rm -rf /tmp/* /var/tmp/* ~/.cache/pip/*
+## Compile and Install Open Street Map protobuf
+RUN wget 'https://github.com/openstreetmap/OSM-binary/archive/v1.3.3.tar.gz' -O - | tar -xz -C /tmp/  \
+    && cd /tmp/OSM-binary-1.3.3/ \
+    && make -C src \
+    && make -C src install \
+    && rm -rf /tmp/*
 
 # Install the latest and Greatest of Git !
 RUN apt-get update \
@@ -65,6 +68,10 @@ RUN wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.26.2.tar.xz 
     && rm -rf /tmp/* /var/tmp/* \
     && git --version
 
+RUN pip install pip virtualenv pipenv -U && \
+	# install dependancies for libc
+	pip install ujson==1.33 numpy==1.9 && \
+	rm -rf /tmp/* /var/tmp/* ~/.cache/pip/*
 
 # add user and group jenkins, with specific userid and groupid, never fail
 RUN groupadd -g 115 jenkins; exit 0


### PR DESCRIPTION
This is achieved by building the following dependencies from source:
 * protobuf v.3.3.1
 * osm-protobuf v.1.3.3

The version being used choosen are based on the version available on Dev
and Jenkins.

The main drawback to this approach is that we don't have way to
replicate any futher changes made to debian8 package onto our production
environement. So we should not update any of those libraries on debian8
unless we make sure they could be deployed by the DevOps.

todo:
 * [x] Test those change with a complete Navitia build and test suite (ie. [navitia/pull/3206/checks](https://github.com/CanalTP/navitia/pull/3206/checks))