### PR TITLE
Revert "Remove dependencies on apt.canaltp.local repo"

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -12,7 +12,7 @@ jobs:
 
       strategy:
           matrix:
-              docker_image_name: [debian8_dev, debian9_dev, debian10_dev]
+              docker_image_name: [debian9_dev, debian10_dev]
 
       steps:
       - uses: actions/checkout@v2

--- a/debian8_dev/Dockerfile
+++ b/debian8_dev/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update && \
 		libgoogle-perftools4 \
 		libgoogle-perftools-dev \
 		vim && \
-    apt-get install -y autoconf automake libtool curl make g++ unzip && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -38,22 +37,20 @@ RUN wget 'https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz' -O - | tar -
     && make altinstall		\
     && rm -rf /tmp/*
 
-# Build and Install Protobuf
-RUN wget 'https://github.com/protocolbuffers/protobuf/archive/v3.3.1.tar.gz' -O - | tar -xz -C /tmp/ \
-    && cd /tmp/protobuf-3.3.1/  \
-    && ./autogen.sh \ 
-    && ./configure --prefix=/usr \
-    && make \
-    && make install \
-    && ldconfig \
-    && rm -rf /tmp/*
+# Add address of the canaltp.local apt server
+RUN echo "deb http://apt.canaltp.local/debian/repositories jessie-dev main" > /etc/apt/sources.list.d/canaltp.list
+RUN echo "nameserver 10.50.83.15" > /etc/resolv.conf \
+		&& apt-get update \
+		# Get the gpg key to authorize downloads from local apt server
+		&& wget --output-document=- http://apt.canaltp.local/debian/repositories/canaltp.gpg.key | apt-key add - \
+		&& apt-get -y --force-yes -t jessie-dev install libosmpbf-dev libprotobuf-dev protobuf-compiler python-protobuf \
+		&& apt-get clean \
+		&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-## Compile and Install Open Street Map protobuf
-RUN wget 'https://github.com/openstreetmap/OSM-binary/archive/v1.3.3.tar.gz' -O - | tar -xz -C /tmp/  \
-    && cd /tmp/OSM-binary-1.3.3/ \
-    && make -C src \
-    && make -C src install \
-    && rm -rf /tmp/*
+RUN pip install pip virtualenv pipenv -U && \
+	# install dependancies for libc
+	pip install ujson==1.33 numpy==1.9 && \
+	rm -rf /tmp/* /var/tmp/* ~/.cache/pip/*
 
 # Install the latest and Greatest of Git !
 RUN apt-get update \
@@ -68,10 +65,6 @@ RUN wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.26.2.tar.xz 
     && rm -rf /tmp/* /var/tmp/* \
     && git --version
 
-RUN pip install pip virtualenv pipenv -U && \
-	# install dependancies for libc
-	pip install ujson==1.33 numpy==1.9 && \
-	rm -rf /tmp/* /var/tmp/* ~/.cache/pip/*
 
 # add user and group jenkins, with specific userid and groupid, never fail
 RUN groupadd -g 115 jenkins; exit 0


### PR DESCRIPTION
Reverts CanalTP/navitia_docker_images#23

Why you may ask ? 
Because it breaks the build of our debian package :( - https://github.com/CanalTP/navitia/runs/626166798?check_suite_focus=true